### PR TITLE
build(deps): remove jupyter lab as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "ubermagutil>=0.62.0",
     "pandas>=1.1",
     "matplotlib>=3.3",
-    "jupyterlab~=3.0",
     "ipywidgets>=7.5"
 ]
 


### PR DESCRIPTION
Jupyter lab is not directly required as a dependency. We move the dependency to the ubermag metapackage, which is our "end-user application".